### PR TITLE
feat: Improve `Past Events`

### DIFF
--- a/_events/20230404.mdx
+++ b/_events/20230404.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2023-04-04T17:00:00.000Z'
 place: The Space, Via dei Lucani 1 Latina
+maps: https://maps.app.goo.gl/4RXKYzYeYPTUkeXBA
 thumbnail: /assets/events/20230404.png
 title: Introduzione Alla Community & Lightning Talks
 description: La community di informatici Pontini, nata nei primi giorni del 2023, finalmente esce allo scoperto, con il primo evento ufficiale! Dopo un'introduzione Alla Community, seguiranno dei Lightning talks dei membri della community!

--- a/_events/20230509.mdx
+++ b/_events/20230509.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2023-05-09T17:00:00.000Z'
 place: The Space, Via dei Lucani 1 Latina
+maps: https://maps.app.goo.gl/4RXKYzYeYPTUkeXBA
 thumbnail: /assets/events/20230509.png
 title: Lightning Talks Vol. 2
 description: La community LiT torna con il secondo appuntamento della stagione 2023, con nuovi speaker! Il programma della serata è il seguente - Antonio Fabrizio con Startup & Imprenditorialità, Fabrizio Cafolla con Open source e progetti, Alessandro Marino con Journey to Cloud Computing e Matteo Benin con Flutter

--- a/_events/20230606.mdx
+++ b/_events/20230606.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2023-06-06T17:00:00.000Z'
 place: The Space, Via dei Lucani 1 Latina
+maps: https://maps.app.goo.gl/4RXKYzYeYPTUkeXBA
 thumbnail: /assets/events/20230606.png
 title: Lightning Talks Vol. 3
 description:  Siamo entusiasti di annunciarvi il prossimo Lightning Talks della community LiT! Si parlerà di Cost Optimization on Google Cloud con Sergio Picca, Panoramica delle Reti mobili e 5G con Alessio Marinelli e KubeCon & operatori Kubernetes con Gabriele Quaresima

--- a/_events/20230629.mdx
+++ b/_events/20230629.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2023-06-29T17:00:00.000Z'
 place: Viridex s.r.l., Via Gennaro Del Prete 2/4 Cisterna di Latina
+maps: https://maps.app.goo.gl/j3t4TmCTohgrCSbF6
 thumbnail: /assets/events/20230629.png
 title: La Giusta Relazione di Lavoro
 description: La community di informatici Pontini torna per un ultimo evento prima dell'estate, questa volta con un ospite d'onore! Direttamente da Treviso, avremo l'opportunità di ascoltare Antonio Dell'Ava, Senior Frontend Dev in eDreams ODIGEO! Antonio ci parlerà della 'Giusta Relazione di Lavoro - Cosa è, Perché succede, Quando cambiare, Come fare a crearla'

--- a/_events/20230922.mdx
+++ b/_events/20230922.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2023-09-22T17:00:00.000Z'
 place: The Space, Via dei Lucani 1 Latina
+maps: https://maps.app.goo.gl/4RXKYzYeYPTUkeXBA
 thumbnail: /assets/events/20230922.webp
 title: Under the hood at Klarna - Managing digital gift cards and leveraging AI
 description: La stagione 2023/2024 della community riparte alla grande, con una collaborazione incredibile! Infatti per l'evento di settembre siamo riusciti ad ottenere una sponsorizzazione da Klarna Engineering. Non è finita qui, perchè avremo come super ospite un Lead Engineer dell'azienda, che ci raggiungerà direttamente da Milano - Antonio Trapani! Antonio ci parlerà di Intelligenza Artificiale e come viene applicata nei progetti Klarna. Inoltre anche Andrea Coluzzi parlerà del suo team, il team Gift Cards!

--- a/src/components/EventWidget.tsx
+++ b/src/components/EventWidget.tsx
@@ -3,19 +3,21 @@ import Image from 'next/image';
 import { MapPinIcon, CalendarIcon } from '@heroicons/react/24/outline';
 import { IEvent } from '@/model/event';
 import { DateTime } from 'luxon';
+import React, { useCallback, useMemo } from 'react';
 
 type Props = {
   event: IEvent;
 };
 
+const thumbHeight = 400;
 const EventWidget: React.FC<Props> = ({ event }: Props) => {
-  const renderEventImage = () => {
+  const renderEventImage = useCallback(() => {
     if (event.thumbnail) {
       return (
         <div className='flex-shrink-0'>
           <Image
-            height={1000}
-            width={500}
+            height={thumbHeight}
+            width={thumbHeight * 1.77}
             src={event.thumbnail}
             className='object-cover'
             alt={`Event cover image ${event.title}`}
@@ -23,11 +25,10 @@ const EventWidget: React.FC<Props> = ({ event }: Props) => {
         </div>
       );
     }
-  };
-  const eventDate = DateTime.fromISO(event.date);
+  }, [event.thumbnail, event.title]);
+  const eventDate = useMemo(() => DateTime.fromISO(event.date), [event.date]);
 
-
-  const getEventWidgetClasses = () => {
+  const getEventWidgetClasses = useCallback(() => {
     const isPastEvent = DateTime.now() > eventDate;
     const baseClasses =
       'flex flex-col overflow-hidden rounded-xl bg-white shadow-lg dark:bg-slate-800';
@@ -36,35 +37,37 @@ const EventWidget: React.FC<Props> = ({ event }: Props) => {
     } else {
       return baseClasses;
     }
-  };
-  const formattedDate = eventDate. toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY);
- 
+  }, [eventDate]);
+  const formattedDate = eventDate.toLocaleString(
+    DateTime.DATETIME_MED_WITH_WEEKDAY
+  );
 
   return (
     <div className={getEventWidgetClasses()}>
-
-     {/* <Link href={`/events/${event.slug}`}> */}
-     
-         {renderEventImage()}
-
-        <div className="flex flex-1 flex-col gap-2 p-4">
-             <div className='flex gap-2'>
-                <CalendarIcon className='block h-6 w-6' aria-hidden='true' />
-                <p>{formattedDate}</p>
-            </div>
-            <div className='flex gap-2'>
-                <MapPinIcon className='block h-6 w-6' aria-hidden='true' />
-                <p>{event.place}</p>
-            </div>
-            <div className='text-xl font-bold text-gray-900 dark:text-slate-200 sm:text-2xl'>
-                <p>{event.title}</p>
-            </div>
-
-            <div className='italic tracking-wide'>
-                <p>{event.description}</p>
-            </div>
+      {renderEventImage()}
+      <div className='flex flex-1 flex-col gap-2 p-4'>
+        <div className='flex gap-2'>
+          <CalendarIcon className='block h-6 w-6' aria-hidden='true' />
+          <p>{formattedDate}</p>
         </div>
-      {/* </Link> */}
+        <div className='flex'>
+          <Link
+            href={event.maps}
+            target={'_blank'}
+            className={'flex gap-2 flex-row'}
+          >
+            <MapPinIcon className='block h-6 w-6' aria-hidden='true' />
+            <p>{event.place}</p>
+          </Link>
+        </div>
+        <div className='text-xl font-bold text-gray-900 dark:text-slate-200 sm:text-2xl'>
+          <p>{event.title}</p>
+        </div>
+
+        <div className='italic tracking-wide'>
+          <p>{event.description}</p>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -21,7 +21,7 @@ export default function EventsList({ heading, caption, events }: Props) {
         </div>
         <div className='mx-auto mt-12 grid max-w-lg gap-5 lg:max-w-none lg:grid-cols-3'>
           {events.map(event => (
-            <EventWidget key={event.slug} event={event}></EventWidget>
+            <EventWidget key={event.slug} event={event} />
           ))}
         </div>
       </div>

--- a/src/model/event.ts
+++ b/src/model/event.ts
@@ -2,6 +2,7 @@ export interface IEvent {
   slug: string;
   date: string;
   place: string;
+  maps: string;
   thumbnail: string;
   title: string;
   description: string;

--- a/src/pages/events/[slug].tsx
+++ b/src/pages/events/[slug].tsx
@@ -1,10 +1,9 @@
 import { serialize } from 'next-mdx-remote/serialize';
 import { GetStaticProps, GetStaticPaths } from 'next';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote';
 
-import EventWidget from '../../components/EventWidget';
-import { getEvent, getAllEvents } from '../../utils/mdxUtils';
+import { getEvent, getAllEvents } from '@/utils/mdxUtils';
 import Prerequisites from '../../components/Prerequisites';
 import { ParsedUrlQuery } from 'querystring';
 import Stacks from '../../components/Stacks';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -85,7 +85,8 @@ export const getStaticProps: GetStaticProps = async () => {
     'date',
     'description',
     'thumbnail',
-    'place'
+    'place',
+    'maps'
   ]);
 
   events.sort((a, b) => (a.date < b.date ? 1 : b.date < a.date ? -1 : 0));

--- a/src/utils/mdxUtils.ts
+++ b/src/utils/mdxUtils.ts
@@ -1,7 +1,7 @@
 import matter from 'gray-matter';
 import { join } from 'path';
 import fs from 'fs';
-
+import * as console from 'console';
 
 type Items = {
   [key: string]: string;
@@ -17,11 +17,7 @@ type Event = {
 const EVENTS_PATH = join(process.cwd(), '_events');
 
 function getEventsFilePaths(): string[] {
-  return (
-    fs
-      .readdirSync(EVENTS_PATH)
-      .filter((path) => /\.mdx?$/.test(path))
-  );
+  return fs.readdirSync(EVENTS_PATH).filter(path => /\.mdx?$/.test(path));
 }
 
 export function getEvent(slug: string): Event {
@@ -37,7 +33,7 @@ export function getEventItems(filePath: string, fields: string[] = []): Items {
 
   const items: Items = {};
 
-  fields.forEach((field) => {
+  fields.forEach(field => {
     if (field === 'slug') {
       items[field] = slug;
     }
@@ -54,7 +50,7 @@ export function getEventItems(filePath: string, fields: string[] = []): Items {
 export function getAllEvents(fields: string[]): Items[] {
   const filePaths = getEventsFilePaths();
   const events = filePaths
-    .map((filePath) => getEventItems(filePath, fields))
+    .map(filePath => getEventItems(filePath, fields))
     .sort((event1, event2) => (event1.date > event2.date ? 1 : -1));
   return events;
 }


### PR DESCRIPTION
Now the address is clickable and it opens (on a new tab) the google map place (it could be useful for fast map navigation)

![image](https://github.com/latina-in-tech/latina-in-tech.github.io/assets/822471/e655401c-a31f-48e1-a3bf-c607cbd9348a)

➕ some minor improvements (`useCallback` and `useMemo` on events rendering)
