### PR TITLE
fix: CI/verify-code doesn't install dependencies

### DIFF
--- a/.github/workflows/verify-code.yml
+++ b/.github/workflows/verify-code.yml
@@ -1,8 +1,10 @@
 name: Verify Code for PR
 
 on:
+  push:
+    branches: ["main"]
   pull_request:
-    types: [opened, reopened]
+    branches: ["main"]
 
 jobs:
   build:

--- a/.github/workflows/verify-code.yml
+++ b/.github/workflows/verify-code.yml
@@ -23,6 +23,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
+      - name: Install Node dependencies
+        run: npm ci --prefer-offline --no-audit
+
       - name: Check types
         run: |
           npm run check:types

--- a/src/@types/assets.ts
+++ b/src/@types/assets.ts
@@ -1,0 +1,3 @@
+declare module '*.jpg';
+declare module '*.jpeg';
+declare module '*.png';

--- a/src/@types/assets.ts
+++ b/src/@types/assets.ts
@@ -1,3 +1,4 @@
 declare module '*.jpg';
 declare module '*.jpeg';
 declare module '*.png';
+declare module '*.svg';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "jsx": "preserve",
     "incremental": true,
     "baseUrl": ".",
+    "typeRoots" : ["node_modules/@types", "src/@types"],
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
This PR changes the `verify-code.yml` workflow to add the install dependencies step and change the workflow execution in order to execute it on every push/coming against the main branch

It also add "type definition" for static assets