### PR TITLE
feat: Add youtube url to event

### DIFF
--- a/_events/20230606.mdx
+++ b/_events/20230606.mdx
@@ -2,6 +2,7 @@
 date: '2023-06-06T17:00:00.000Z'
 place: The Space, Via dei Lucani 1 Latina
 maps: https://maps.app.goo.gl/4RXKYzYeYPTUkeXBA
+youtubeUrl: https://www.youtube.com/watch?v=araCZjntJRw
 thumbnail: /assets/events/20230606.png
 title: Lightning Talks Vol. 3
 description:  Siamo entusiasti di annunciarvi il prossimo Lightning Talks della community LiT! Si parlerà di Cost Optimization on Google Cloud con Sergio Picca, Panoramica delle Reti mobili e 5G con Alessio Marinelli e KubeCon & operatori Kubernetes con Gabriele Quaresima

--- a/src/components/EventWidget.tsx
+++ b/src/components/EventWidget.tsx
@@ -7,6 +7,7 @@ import React, { useCallback, useMemo } from 'react';
 import { AddToCalendarButton } from 'add-to-calendar-button-react';
 import ReactMarkdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
+import { SlSocialYoutube } from 'react-icons/sl';
 
 type AddToCalendarProps = {
   eventDateTime: DateTime;
@@ -136,6 +137,18 @@ const EventWidget: React.FC<Props> = ({ event }: Props) => {
             <p>{event.place}</p>
           </Link>
         </div>
+        {event.youtubeUrl && (
+          <div className='flex'>
+            <Link
+              href={event.youtubeUrl}
+              target={'_blank'}
+              className={'flex gap-2 flex-row'}
+            >
+              <SlSocialYoutube className='block h-6 w-6' aria-hidden='true' />
+              <p>vedi su youtube</p>
+            </Link>
+          </div>
+        )}
         <div className='text-xl font-bold text-gray-900 dark:text-slate-200 sm:text-2xl'>
           <p>{event.title}</p>
         </div>

--- a/src/model/event.ts
+++ b/src/model/event.ts
@@ -5,6 +5,7 @@ export interface IEvent {
   place: string;
   maps: string;
   duration?: Minute;
+  youtubeUrl?: string;
   thumbnail: string;
   title: string;
   description: string;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -86,6 +86,7 @@ export const getStaticProps: GetStaticProps = async () => {
     'description',
     'thumbnail',
     'duration',
+    'youtubeUrl',
     'place',
     'maps'
   ]);

--- a/src/utils/mdxUtils.ts
+++ b/src/utils/mdxUtils.ts
@@ -1,7 +1,6 @@
 import matter from 'gray-matter';
 import { join } from 'path';
 import fs from 'fs';
-import * as console from 'console';
 
 type Items = {
   [key: string]: string;
@@ -49,8 +48,7 @@ export function getEventItems(filePath: string, fields: string[] = []): Items {
 
 export function getAllEvents(fields: string[]): Items[] {
   const filePaths = getEventsFilePaths();
-  const events = filePaths
+  return filePaths
     .map(filePath => getEventItems(filePath, fields))
     .sort((event1, event2) => (event1.date > event2.date ? 1 : -1));
-  return events;
 }


### PR DESCRIPTION
# 📚 Description
## What
This PR adds the ability to add `youtubeUrl` to the event data
<!-- Explain what this PR addresses: what this will do once merged? -->
## Why
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
As a user, I would like to watch the event whenever I want
# 🧪 Testing Guide
<!-- A testing plan to verify this code is very appreciated. Add here the steps to follow to verify the code -->
Manual test, run the application

# 🖼 Screenshots/Recordings
<!-- Do you have any images/videos to attach to this PR as an asset to add more context for the reviewer? -->
| before | after |
|--------|--------|
| ![prima](https://github.com/latina-in-tech/latina-in-tech.github.io/assets/822471/fb854e75-560e-4355-88e7-e51d6fdb9f69) | ![dopo](https://github.com/latina-in-tech/latina-in-tech.github.io/assets/822471/7494c6a5-dfd1-47ad-ba5e-123633adde67) | 
