### PR TITLE
fix: Admin team item is not highlighted on mobile screens

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -93,7 +93,7 @@ const Header: React.FC = () => {
 
           <Disclosure.Panel className='lg:hidden'>
             <div className='space-y-1 px-2 pt-2 pb-3'>
-              {navigationLinks.map(item => (
+              {links.map(item => (
                 <Disclosure.Button
                   as={Link}
                   key={item.name}


### PR DESCRIPTION
# 📚 Description
This PR fixes a bug that doesn't consider the current item in the `Disclosure` panel