### PR TITLE
feat: Add slides event of 2024.01.16

### DIFF
--- a/_events/20240116.mdx
+++ b/_events/20240116.mdx
@@ -13,6 +13,10 @@ speakers:
     '{"name": "Alessio Dore", "role": "Head of IO Platform", "company": "PagoPA S.p.A.", "thumbnail": "/assets/speakers/20240116/dore.png", "linkedinUrl": "https://www.linkedin.com/in/alessio-dore/"}',
   ]
 tags: ['Functional Programming', 'Architectures', 'Web Application', 'Environments']
+slides: [
+'{"url":  "https://drive.google.com/file/d/1p8_NWs8nlxDhdzSLY7SHS7riDjXSl2rD/view?usp=drive_link", "speakerName": "Emanuele De Cupis", "title": "fp-ts spiegato a mio figlio"}',
+'{"url":  "https://drive.google.com/file/d/1xyocMgiRbNelN6yqIanSwnPNR1bHYUSY/view?usp=drive_link", "speakerName": "Alessio Dore", "title": "Mono ambiente e rollout"}'
+]
 ---
 
 [PagoPA](https://www.pagopa.it/it/), in particolare con la [piattaforma IO](https://ioapp.it/it), mette a disposizione un unico punto di accesso per interagire in modo semplice e sicuro con i servizi pubblici locali e nazionali, direttamente da mobile app.

--- a/src/components/event/EventSlides.tsx
+++ b/src/components/event/EventSlides.tsx
@@ -13,7 +13,7 @@ export default function EventsSlides({ slides }: Props) {
       <h2 className='text-2xl font-bold'>Slides</h2>
       <div className='mx-auto mt-6 grid max-w-lg gap-5 lg:max-w-none lg:grid-cols-3'>
         {slides.map(slide => (
-          <Link href={slide.url} key={slide.url} legacyBehavior>
+          <a target='_blank' rel='noreferrer' href={slide.url} key={slide.url}>
             <div className='flex cursor-pointer items-center justify-center align-baseline gap-2 bg-slate-300 rounded-full py-2 px-4 font-semibold hover:bg-slate-200 dark:bg-slate-700 dark:text-white dark:hover:600 dark:hover:text-slate-600'>
               <div className='flex items-center'>
                 <PresentationChartLineIcon className='block h-6 w-6' />
@@ -23,7 +23,7 @@ export default function EventsSlides({ slides }: Props) {
                 {slide.speakerName} - {slide.title}
               </p>
             </div>
-          </Link>
+          </a>
         ))}
       </div>
     </div>

--- a/src/components/event/EventSlides.tsx
+++ b/src/components/event/EventSlides.tsx
@@ -1,5 +1,4 @@
 import { ISlides } from '@/model/event';
-import Link from 'next/link';
 import React from 'react';
 import { PresentationChartLineIcon } from '@heroicons/react/24/outline';
 


### PR DESCRIPTION
It also changes the way how the link to the slides is opened: since it is an external link we don't need to use `Link` from NextJS. It has been replace with a standard `<a>` with the capability to open the slide in a dedicated tab