### PR TITLE
chore: Add stale CI action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. If the issue is still present, please leave a comment within 7 days to keep it open, otherwise it will be closed automatically.'
           close-issue-message: 'This issue was closed because it has been inactive for 7 days since being marked as stale.'
           stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. If the pull request is still valid, please update it within 7 days to keep it open or merge it, otherwise it will be closed automatically.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '0 2 1/7 * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. If the issue is still present, please leave a comment within 7 days to keep it open, otherwise it will be closed automatically.'
+          close-issue-message: 'This issue was closed because it has been inactive for 7 days since being marked as stale.'
+          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. If the pull request is still valid, please update it within 7 days to keep it open or merge it, otherwise it will be closed automatically.'
+          close-pr-message: 'This pull request was closed because it has been inactive for 7 days since being marked as stale.'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          days-before-stale: 30
+          days-before-close: 7
+          remove-stale-when-updated: true
+          exempt-all-assignees: true
+          exempt-issue-labels: 'keep open'
+


### PR DESCRIPTION
This PR adds a new action to mark issues and pull requests that have not had a recent interaction
It acts in this way

- Add a label "Stale" on issues and pull requests after 30 days of inactivity and comment on them
- Close the stale issues and pull requests after 7 days of inactivity
- If an update/comment occurs on stale issues or pull requests, the stale label will be removed and the timer will restart