### PR TITLE
fix: community member list doesn't shuffle members 

### DIFF
--- a/src/pages/community/index.tsx
+++ b/src/pages/community/index.tsx
@@ -26,7 +26,11 @@ const CommunityMemberList: React.FC<
     [members]
   );
   const validMembers: CommunityMemberValid[] = useMemo(
-    () => members.filter(isCommunityMember),
+    () =>
+      members
+        .filter(isCommunityMember)
+        // shuffle the array to avoid always showing the same members at the same position
+        .sort(() => 0.5 - Math.random()),
     [members]
   );
   /**

--- a/src/utils/community.ts
+++ b/src/utils/community.ts
@@ -48,8 +48,6 @@ export const getAllCommunityMembers = (): Array<CommunityMemberOrError> =>
       ),
       filePath
     }))
-    // shuffle the array to avoid always showing the same members at the same position
-    .sort(() => 0.5 - Math.random())
     .map(({ fileContent, filePath }) => {
       const { data } = matter(fileContent);
       // validate against a schema the read data


### PR DESCRIPTION
To ensure the same visibility for all members, the list should be displayed in a different order on every render.
This is not true since the order of the members is computed at build time.
Now it has been moved on client logic