### PR TITLE
feat: Speakers/Slides safe parse

### DIFF
--- a/_events/20240403.mdx
+++ b/_events/20240403.mdx
@@ -9,8 +9,8 @@ title: AI Talks - Volume I
 description: "ChatGPT ha conquistato il mondo? Evento di networking e divulgazione sull'Intelligenza Artificiale gratuito, apericena inclusa!"
 speakers:
   [
-    '{"name2": "Lorenzo Tronchin", "role": "PhD Student", "company": "Università Campus Bio-Medico di Roma", "thumbnail": "/assets/speakers/ltronchin.jpg", "linkedinUrl": "https://www.linkedin.com/in/lorenzotronchin/"}',
-     '{"name": "Federico Califano", "role": 4, "company": "AI Sparks", "thumbnail": "/assets/speakers/fcalifano.jpg", "linkedinUrl": "foo"}',
+    '{"name": "Lorenzo Tronchin", "role": "PhD Student", "company": "Università Campus Bio-Medico di Roma", "thumbnail": "/assets/speakers/ltronchin.jpg", "linkedinUrl": "https://www.linkedin.com/in/lorenzotronchin/"}',
+     '{"name": "Federico Califano", "role": "Co-Founder", "company": "AI Sparks", "thumbnail": "/assets/speakers/fcalifano.jpg", "linkedinUrl": "https://www.linkedin.com/in/federicocalifano/"}',
   ]
 tags: ['AI', 'ChatGPT']
 ---

--- a/_events/20240403.mdx
+++ b/_events/20240403.mdx
@@ -9,8 +9,8 @@ title: AI Talks - Volume I
 description: "ChatGPT ha conquistato il mondo? Evento di networking e divulgazione sull'Intelligenza Artificiale gratuito, apericena inclusa!"
 speakers:
   [
-    '{"name": "Lorenzo Tronchin", "role": "PhD Student", "company": "Università Campus Bio-Medico di Roma", "thumbnail": "/assets/speakers/ltronchin.jpg", "linkedinUrl": "https://www.linkedin.com/in/lorenzotronchin/"}',
-     '{"name": "Federico Califano", "role": "Co-Founder", "company": "AI Sparks", "thumbnail": "/assets/speakers/fcalifano.jpg", "linkedinUrl": "https://www.linkedin.com/in/federicocalifano/"}',
+    '{"name2": "Lorenzo Tronchin", "role": "PhD Student", "company": "Università Campus Bio-Medico di Roma", "thumbnail": "/assets/speakers/ltronchin.jpg", "linkedinUrl": "https://www.linkedin.com/in/lorenzotronchin/"}',
+     '{"name": "Federico Califano", "role": 4, "company": "AI Sparks", "thumbnail": "/assets/speakers/fcalifano.jpg", "linkedinUrl": "foo"}',
   ]
 tags: ['AI', 'ChatGPT']
 ---

--- a/src/model/event.ts
+++ b/src/model/event.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-
+import * as z from 'zod';
 export type Minute = number;
 export interface IEvent {
   slug: string;
@@ -17,19 +17,23 @@ export interface IEvent {
   signup: string;
 }
 
-export interface ISlides {
-  url: string;
-  title: string;
-  speakerName: string;
-}
+export const slidesSchema = z.object({
+  url: z.string().url(),
+  title: z.string(),
+  speakerName: z.string()
+});
 
-export interface ISpeaker {
-  name: string;
-  role: string;
-  company: string;
-  thumbnail: string;
-  linkedinUrl: string;
-}
+export type ISlides = z.infer<typeof slidesSchema>;
+
+export const speakerSchema = z.object({
+  name: z.string(),
+  role: z.string(),
+  company: z.string(),
+  thumbnail: z.string(),
+  linkedinUrl: z.string().url()
+});
+
+export type ISpeaker = z.infer<typeof speakerSchema>;
 
 export const EVENT_FIELDS = [
   'title',

--- a/src/pages/events/[slug].tsx
+++ b/src/pages/events/[slug].tsx
@@ -27,7 +27,11 @@ type ParseItemsReturn<T> = {
   errors: string[];
 };
 
-// given a list of string representing a JSON
+/**
+ * given a list of string representing a T object, it tries
+ * to parse each string into a T object using the provided schema
+ * if the parsing fails, it returns the errors
+ */
 const parseItems = <T,>(
   items: string[],
   schema: ZodSchema<T>

--- a/src/pages/events/[slug].tsx
+++ b/src/pages/events/[slug].tsx
@@ -22,15 +22,16 @@ type Props = {
   frontMatter: IEvent;
 };
 
-type ParseItemReturn<T> = {
+type ParseItemsReturn<T> = {
   items: T[];
   errors: string[];
 };
 
+// given a list of string representing a JSON
 const parseItems = <T,>(
   items: string[],
   schema: ZodSchema<T>
-): ParseItemReturn<T> => {
+): ParseItemsReturn<T> => {
   const parsed = items.map(item => schema.safeParse(JSON.parse(item)));
   return parsed.reduce(
     (acc, curr) => {
@@ -42,7 +43,7 @@ const parseItems = <T,>(
         errors: [...acc.errors, ...curr.error.errors.map(e => e.message)]
       };
     },
-    { items: [], errors: [] } as ParseItemReturn<T>
+    { items: [], errors: [] } as ParseItemsReturn<T>
   );
 };
 


### PR DESCRIPTION
This PR aims to avoid runtime error due to a possible wrong data format.
Indeed speakers and slides are strings representing JSON objects. The current code assumes that they have a specific shape.

The proposed code ensures that the data respects what the code needs and if any errors is detected, they will be excluded from rendering. If you are in dev environment eny errors will be printed in place of the expected component. In production will be rendered only valid elements

![Screenshot 2024-04-03 alle 12 10 32](https://github.com/latina-in-tech/latina-in-tech.github.io/assets/822471/9484ae6b-1a17-42fc-b5b1-3d00daf359e4)
