### PR TITLE
fix: Slides component is rendered even when there are no slides

### DIFF
--- a/src/pages/events/[slug].tsx
+++ b/src/pages/events/[slug].tsx
@@ -119,7 +119,7 @@ const EventPage: React.FC<Props> = ({ source, frontMatter: event }: Props) => {
 
         <div className='flex flex-col items-center justify-center px-16 gap-8 md:flex-row'>
           <EventActions event={event} />
-          {speakersObjects && (
+          {speakers.length > 0 && (
             <div className='grid grid-cols-1 gap-4 md:grid-cols-3'>
               {speakers.map(speaker => {
                 return (
@@ -161,7 +161,7 @@ const EventPage: React.FC<Props> = ({ source, frontMatter: event }: Props) => {
 
           <div className='flex flex-col gap-4'>
             <EventDescription event={event} />
-            {slidesObjects && <EventsSlides slides={slides} />}
+            {slides.length > 0 && <EventsSlides slides={slides} />}
           </div>
         </div>
 


### PR DESCRIPTION
This is due to a wrong render condition

![Screenshot 2024-04-05 alle 10 08 25](https://github.com/latina-in-tech/latina-in-tech.github.io/assets/822471/ff277125-3192-4ebb-be8e-c5c8677d492e)

