### PR TITLE
fix: Event validation parse wrong data

### DIFF
--- a/_events/20240704.mdx
+++ b/_events/20240704.mdx
@@ -1,5 +1,5 @@
 ---
-date: '2024-06-27T17:00:00.000Z'
+date: '2024-07-04T17:00:00.000Z'
 duration: 120
 place: Spazio Attivo Latina Lazio Innova - Via Carlo Alberto, 22, 04100 Latina LT
 maps: https://maps.app.goo.gl/eEYY5qwaSUU92b7Y6

--- a/src/utils/mdxUtils.ts
+++ b/src/utils/mdxUtils.ts
@@ -28,7 +28,7 @@ export function getEvent(slug: string): Event {
   return { data, content };
 }
 
-export function getEventItems(filePath: string, fields: string[] = []): IEvent {
+function getEventItems(filePath: string, fields: string[] = []): IEvent {
   const slug = filePath.replace(/\.mdx?$/, '');
   const { data, content } = getEvent(slug);
   const items: Items = {};
@@ -54,7 +54,7 @@ export function getEventItems(filePath: string, fields: string[] = []): IEvent {
         path: ['thumbnail']
       })
     )
-    .safeParse(items);
+    .safeParse({ ...data, slug });
   if (!maybeEvent.success) {
     throw new Error(
       `Error parsing ${filePath}: ${maybeEvent.error.errors.map(e => `${e.path} - ${e.message}`).join(', ')}`


### PR DESCRIPTION
This PR fixes a bug that causes an error during the building phase.
The event zod validator parse a partial data that in dev mode it's always good but during the build it's diffirent since next has to build the pages based on slugs.