### PR TITLE
Redesign event detail layout

### DIFF
--- a/src/pages/[lang]/events/[slug].tsx
+++ b/src/pages/[lang]/events/[slug].tsx
@@ -1,5 +1,5 @@
 import { GetStaticProps, GetStaticPaths } from 'next';
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { getEvent, getAllEvents, getEventFromSlug } from '@/utils/mdxUtils';
 import { ParsedUrlQuery } from 'querystring';
@@ -10,14 +10,15 @@ import rehypeRaw from 'rehype-raw';
 import Image from 'next/image';
 import Header from '@/components/Header';
 import EventActions from '@/components/event/EventActions';
-import EventDescription from '@/components/event/EventDescription';
 import { Helmet } from 'react-helmet';
-import EventTags from '@/components/event/EventTags';
-import EventsSlides from '@/components/event/EventSlides';
 import { ZodSchema } from 'zod';
 import { i18n } from 'i18n.config';
 import { useRouter } from 'next/router';
 import { getAllLocales } from '@/utils/locale';
+import {
+  ArrowTopRightOnSquareIcon,
+  PresentationChartLineIcon
+} from '@heroicons/react/24/outline';
 
 type Props = {
   source: string;
@@ -53,8 +54,6 @@ const parseItems = <T,>(
   );
 };
 
-const thumbHeight = 250;
-
 const EventPage: React.FC<Props> = ({ source, frontMatter: event }: Props) => {
   const router = useRouter();
   const locale = i18n.locales.filter(
@@ -68,23 +67,6 @@ const EventPage: React.FC<Props> = ({ source, frontMatter: event }: Props) => {
   const slides = slidesObjects.items;
 
   const speakers = useMemo(() => event.speakers ?? [], [event.speakers]);
-
-  const renderEventImage = useCallback(() => {
-    if (event.thumbnail) {
-      return (
-        <div className='flex-shrink-0'>
-          <Image
-            height={thumbHeight}
-            width={thumbHeight * 1.77}
-            src={event.thumbnail}
-            className='object-cover group-hover:brightness-110'
-            alt={`Event cover image ${event.title}`}
-          />
-        </div>
-      );
-    }
-  }, [event.thumbnail, event.title]);
-
   return (
     <>
       {/* If you use nextjs's Head component here, you will get a warning in the console:
@@ -96,107 +78,209 @@ const EventPage: React.FC<Props> = ({ source, frontMatter: event }: Props) => {
         <title>LiT - {event.title}</title>
       </Helmet>
       <Header lang={locale} />
-      <article className='flex flex-col gap-4 px-4 pb-8 justify-center items-center'>
-        <h2 className='text-3xl font-extrabold text-center text-gray-900 dark:text-slate-200 sm:text-4xl'>
-          {event.title}
-        </h2>
-        <div className='md:px-20 w-full md:max-w-[60%]'>
-          <EventTags event={event} />
-        </div>
+      <main className='bg-slate-50/70 px-4 pb-16 pt-8 dark:bg-slate-900 sm:px-6 sm:pt-12 lg:px-8'>
+        <article className='mx-auto max-w-7xl'>
+          <header className='mx-auto mb-10 max-w-4xl text-center sm:mb-14'>
+            <h1 className='text-3xl font-extrabold tracking-tight text-gray-900 dark:text-slate-100 sm:text-5xl'>
+              {event.title}
+            </h1>
+          </header>
 
-        <div className='flex flex-col items-center justify-center px-16 gap-8 md:flex-row'>
-          <EventActions event={event} />
-          {speakers.length > 0 && (
-            <div className='grid grid-cols-1 gap-4 md:grid-cols-3'>
-              {speakers.map(speaker => {
-                return (
-                  <div key={speaker.name} className='flex gap-4 items-center'>
-                    <img
-                      className='object-cover w-20 h-20 rounded-full shadow-md'
-                      src={speaker.thumbnail}
-                      alt='avatar'
-                    />
-                    <div className='flex flex-col gap-2'>
-                      <p className='font-bold'>{speaker.name}</p>
-                      <p className='text-sm'>
-                        {speaker.role}{' '}
-                        {speaker.company && (
-                          <span className='font-semibold'>
-                            @ {speaker.company}
-                          </span>
-                        )}
-                      </p>
+          <div className='grid items-start gap-8 lg:grid-cols-[minmax(0,36rem)_20rem] lg:justify-center lg:gap-8 xl:grid-cols-[36rem_22rem] xl:gap-12'>
+            <div className='relative aspect-video overflow-hidden rounded-2xl bg-slate-200 shadow-lg ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700 sm:rounded-3xl lg:col-start-1 lg:w-full'>
+              <Image
+                fill
+                priority
+                sizes='(min-width: 1024px) 576px, calc(100vw - 32px)'
+                src={event.thumbnail}
+                className='object-cover'
+                alt={`Event cover image ${event.title}`}
+              />
+            </div>
+
+            <aside className='rounded-2xl bg-white p-4 shadow-md ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700 sm:p-6 lg:col-start-2 lg:row-start-1 lg:row-span-2'>
+              {event.tags.length > 0 && (
+                <section className='mb-6 border-b border-slate-200 pb-6 dark:border-slate-700'>
+                  <ul
+                    className='flex flex-wrap gap-2'
+                    aria-label='Event topics'
+                  >
+                    {event.tags.map(tag => (
+                      <li
+                        key={tag}
+                        className='rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold tracking-wide text-primary dark:bg-primary-lighter/10 dark:text-primary-lighter'
+                      >
+                        {tag}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              <div className='[&>div>a:nth-child(2)_svg]:h-7 [&>div>a:nth-child(2)_svg]:w-7 [&>div>a:nth-child(2)_svg]:shrink-0'>
+                <EventActions event={event} />
+              </div>
+
+              {speakers.length > 0 && (
+                <section className='mt-6 border-t border-slate-200 pt-6 dark:border-slate-700'>
+                  <h2 className='text-lg font-bold text-gray-900 dark:text-slate-100'>
+                    Speaker
+                  </h2>
+                  <div className='mt-4 flex flex-col gap-5'>
+                    {speakers.map(speaker => (
+                      <article
+                        key={speaker.name}
+                        className='flex items-start gap-3'
+                      >
+                        <img
+                          className='h-14 w-14 flex-shrink-0 rounded-full object-cover shadow-md'
+                          src={speaker.thumbnail}
+                          alt={speaker.name}
+                        />
+                        <div className='min-w-0 flex-1'>
+                          <div className='flex items-start justify-between gap-2'>
+                            <h3 className='text-sm font-bold leading-5 text-gray-900 dark:text-slate-100'>
+                              {speaker.name}
+                            </h3>
+                            <a
+                              href={speaker.linkedinUrl}
+                              className='flex-shrink-0 rounded text-slate-600 transition-colors hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary dark:text-slate-300 dark:hover:text-primary-lighter'
+                              target='_blank'
+                              rel='noreferrer'
+                            >
+                              <span className='sr-only'>
+                                LinkedIn - {speaker.name}
+                              </span>
+                              <BsLinkedin className='h-4 w-4' />
+                            </a>
+                          </div>
+                          <p className='mt-1 text-xs leading-5 text-slate-600 dark:text-slate-300'>
+                            {speaker.role}{' '}
+                            {speaker.company && (
+                              <span className='font-semibold'>
+                                @ {speaker.company}
+                              </span>
+                            )}
+                          </p>
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {slides.length > 0 && (
+                <section className='mt-6 border-t border-slate-200 pt-6 dark:border-slate-700'>
+                  <h2 className='text-lg font-bold text-gray-900 dark:text-slate-100'>
+                    Slides
+                  </h2>
+                  <div className='mt-4 flex flex-col gap-3'>
+                    {slides.map(slide => (
                       <a
-                        href={speaker.linkedinUrl}
-                        className='text-slate-800 hover:text-slate-600 dark:text-slate-100 dark:hover:text-white'
+                        key={slide.url}
+                        href={slide.url}
                         target='_blank'
                         rel='noreferrer'
+                        className='group flex items-start gap-3 rounded-xl bg-slate-50 p-3 ring-1 ring-slate-200 transition-colors hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900 dark:ring-slate-700 dark:hover:bg-slate-700'
                       >
-                        <span className='sr-only'>LinkedIn</span>
-                        <BsLinkedin />
+                        <PresentationChartLineIcon className='h-5 w-5 flex-shrink-0 text-primary dark:text-primary-lighter' />
+                        <span className='min-w-0 flex-1'>
+                          <span className='block text-xs font-medium text-slate-500 dark:text-slate-400'>
+                            {slide.speakerName}
+                          </span>
+                          <span className='mt-1 block text-sm font-semibold leading-5 text-gray-900 dark:text-slate-100'>
+                            {slide.title}
+                          </span>
+                        </span>
+                        <ArrowTopRightOnSquareIcon className='h-4 w-4 flex-shrink-0 text-slate-400 transition-colors group-hover:text-primary dark:group-hover:text-primary-lighter' />
                       </a>
-                    </div>
+                    ))}
                   </div>
-                );
-              })}
+                </section>
+              )}
+            </aside>
+
+            <div className='flex flex-col gap-8 lg:col-start-1'>
+              <section className='rounded-2xl border-l-4 border-primary bg-white p-5 text-lg leading-8 text-slate-700 shadow-sm dark:bg-slate-800 dark:text-slate-200 sm:p-7'>
+                <ReactMarkdown
+                  components={{
+                    a: ({ ...props }) => (
+                      <a
+                        {...props}
+                        target='_blank'
+                        rel='noreferrer'
+                        className='font-semibold text-primary underline decoration-primary-lighter underline-offset-4 transition-colors hover:text-primary-dark dark:text-primary-lighter dark:hover:text-primary-light'
+                      />
+                    )
+                  }}
+                  rehypePlugins={[rehypeRaw]}
+                  allowedElements={[
+                    'p',
+                    'b',
+                    'i',
+                    'em',
+                    'strong',
+                    'a',
+                    'li',
+                    'ul',
+                    'ol',
+                    'br'
+                  ]}
+                >
+                  {event.description}
+                </ReactMarkdown>
+              </section>
+
+              {source && (
+                <section className='prose prose-slate max-w-none rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 prose-img:w-full prose-img:rounded-xl dark:prose-invert dark:bg-slate-800 dark:ring-slate-700 sm:p-8'>
+                  <ReactMarkdown
+                    components={{
+                      a: ({ ...props }) => (
+                        <a
+                          {...props}
+                          target='_blank'
+                          rel='noreferrer'
+                          className='text-primary underline decoration-primary-lighter underline-offset-4 transition-colors hover:text-primary-dark dark:text-primary-lighter dark:hover:text-primary-light'
+                        />
+                      ),
+                      h1: ({ ...props }) => (
+                        <h1
+                          {...props}
+                          className='text-3xl font-bold text-primary dark:text-primary-lighter'
+                        />
+                      ),
+                      h2: ({ ...props }) => (
+                        <h2
+                          {...props}
+                          className='text-xl font-bold text-primary-dark dark:text-primary-light'
+                        />
+                      )
+                    }}
+                    rehypePlugins={[rehypeRaw]}
+                    allowedElements={[
+                      'p',
+                      'b',
+                      'i',
+                      'em',
+                      'strong',
+                      'a',
+                      'li',
+                      'ul',
+                      'ol',
+                      'br',
+                      'h1',
+                      'h2',
+                      'img'
+                    ]}
+                  >
+                    {source}
+                  </ReactMarkdown>
+                </section>
+              )}
             </div>
-          )}
-        </div>
-
-        <div className='p-4 md:px-16 md:py-8 flex flex-col gap-8 items-center justify-center md:flex-row'>
-          {renderEventImage()}
-
-          <div className='flex flex-col gap-4'>
-            <EventDescription event={event} />
-            {slides.length > 0 && <EventsSlides slides={slides} />}
           </div>
-        </div>
-
-        <div className='max-w-6xl'>
-          <ReactMarkdown
-            components={{
-              a: ({ ...props }) => (
-                <a
-                  {...props}
-                  target='_blank'
-                  className='underline hover:bg-primary-lighter hover:rounded-xl hover:p-2 dark:hover:bg-primary-dark'
-                  onClick={event => event.stopPropagation()}
-                />
-              ),
-              h1: ({ ...props }) => (
-                <h1
-                  {...props}
-                  className='text-primary dark:text-primary-lighter text-3xl font-bold'
-                />
-              ),
-              h2: ({ ...props }) => (
-                <h2
-                  {...props}
-                  className='text-primary-dark dark:text-primary-light text-xl font-bold'
-                />
-              )
-            }}
-            rehypePlugins={[rehypeRaw]}
-            allowedElements={[
-              'p',
-              'b',
-              'i',
-              'em',
-              'strong',
-              'a',
-              'li',
-              'ul',
-              'ol',
-              'br',
-              'h1',
-              'h2',
-              'img'
-            ]}
-          >
-            {source}
-          </ReactMarkdown>
-        </div>
-      </article>
+        </article>
+      </main>
     </>
   );
 };


### PR DESCRIPTION
## Summary

- Reorganize the event detail into a responsive content column and aside.
- Move tags, speakers, and slides into the aside.
- Improve content hierarchy and slide links.

## Screenshots

| PRE | POST |
| --- | --- |
|  <img width="2400" height="2800" alt="lit_pre" src="https://github.com/user-attachments/assets/c3eb6168-5935-44e9-8ba7-bf7f76bc7992" /> | <img width="2538" height="2568" alt="lit_post" src="https://github.com/user-attachments/assets/7f3a9cb3-52f3-4e75-adda-1d353368c160" /> |

## Checks

- ESLint
- Prettier
- Event data validation